### PR TITLE
docs: sync brand-intel docs to 3-channel W7

### DIFF
--- a/brand-intel/ARCHITECTURE.md
+++ b/brand-intel/ARCHITECTURE.md
@@ -15,7 +15,7 @@
 **In scope today (4 pipelines + UX patches):**
 - **W9 `competitor-radar`** — Peec snapshot ingest (з `data/peec-snapshot.json`, refreshed manually via Claude Code session) + Tavily fresh news (supplementary, live). Delta detect → severity+sentiment classify → if `severity='high'` auto-counter-draft. Manual trigger demo today.
 - **W5 `narrative-simulator`** — own LLM panels (gpt-4o + claude-sonnet). Outputs include avg_position, mention_rate, predicted_sentiment. On-demand trigger.
-- **W7 `content-expand`** — один approved counter-draft → 4 channel variants (blog ~800w, X thread 5 tweets, LinkedIn ~200w, email subject+body). Auto-trigger після counter-draft approval.
+- **W7 `content-expand`** — один approved counter-draft → 3 channel variants (blog ~800w, X thread 3-7 tweets, LinkedIn ~200w). Auto-trigger після counter-draft approval.
 - **W6′ `morning-brief`** — daily 8am UTC LLM-synthesized 200w summary → real Slack send via incoming webhook. Cron post-hackathon, manual "Send now" button demo today.
 - `/demo/[brand]` dashboard з 7 sections (audit, competitors, signals, drafts queue, simulator outputs, multi-channel content, morning brief).
 - `competitors` table з `relationship='self'|'competitor'` (self-monitoring через ту саму machinery).

--- a/brand-intel/PIPELINES.md
+++ b/brand-intel/PIPELINES.md
@@ -9,7 +9,7 @@
 > **Pipeline-by-pipeline:**
 > - **W9 Competitor Radar:** Peec snapshot file `data/peec-snapshot.json` (refreshed manually via Claude Code MCP session, sentiment+position+citations native у snapshot) + Tavily fresh news (live, supplementary). Manual trigger demo today. ALL severities у `signals` table; auto-draft тільки для `severity='high'`; medium = on-demand button. Reads `competitors` з `relationship='self'|'competitor'`. Stats aggregated у `runs.stats jsonb`.
 > - **W5 Narrative Simulator:** trigger manual через "Simulate alternatives" button on counter-draft або signal. Own LLM panels (gpt-4o + claude-sonnet, 5 prompts × 2 models × 3 variants). Persists у `narrative_variants` з `mention_rate`, `avg_position`, `predicted_sentiment`. Score formula: `mention_rate × (1 / avg_position)`.
-> - **W7 Multi-channel Expand:** auto-trigger на counter-draft approval. Один approved → 4 channel variants (blog ~800w, X thread 5 tweets, LinkedIn ~200w, email subject+body). Persists у `content_variants` table. Spec → `features/content-expansion.md`.
+> - **W7 Multi-channel Expand:** auto-trigger на counter-draft approval. Один approved → 3 channel variants (blog ~800w, X thread 3-7 tweets, LinkedIn ~200w). Persists у `content_variants` table. Spec → `features/content-expansion.md`.
 > - **W6′ Morning Brief:** manual "Send now" button demo today, daily 8am UTC cron post-hackathon. Aggregates yesterday's signals + drafts + Peec brand pulse → ~200w summary → real Slack send via incoming webhook. Persists у `brief_deliveries`. Spec → `features/morning-brief.md`.
 
 ---

--- a/brand-intel/README.md
+++ b/brand-intel/README.md
@@ -28,7 +28,7 @@ Plugin-era docs — у `_archive/` як superseded.
 
 **W6′ — Morning brief Slack.** `[ACTIVE]` Daily 8am UTC text summary (~200w) → real Slack send via incoming webhook. Persists у `brief_deliveries` table. Spec → `features/morning-brief.md`.
 
-**W7 — Multi-channel expand.** `[ACTIVE]` Один approved counter-draft → 4 variants (blog ~800w, X thread 5 tweets, LinkedIn ~200w, email subject+body). Auto-trigger на counter-draft approval. Persists у `content_variants`. Spec → `features/content-expansion.md`.
+**W7 — Multi-channel expand.** `[ACTIVE]` Один approved counter-draft → 3 variants (blog ~800w, X thread 3-7 tweets, LinkedIn ~200w). Auto-trigger на counter-draft approval. Persists у `content_variants`. Spec → `features/content-expansion.md`.
 
 **W9 — Competitor radar.** `[ACTIVE]` Peec snapshot (`data/peec-snapshot.json`, refreshed manually via Claude Code MCP session) + Tavily fresh news → класифікує signals по severity+sentiment → для `severity=high` автоматично генерує counter-draft зі `status='draft'`. Human approval обов'язкова перед publish (див. `decisions/2026-04-24-counter-draft-severity-high-only.md`).
 

--- a/brand-intel/RUNBOOK.md
+++ b/brand-intel/RUNBOOK.md
@@ -388,7 +388,7 @@ Dashboard → Functions → click function → "Pause". Useful коли знай
 - [ ] Open `/demo/attio` + Inngest UI + Slack у split screen.
 - [ ] Start з 1-sentence pitch ("BBH = intelligence layer над Peec MCP").
 - [ ] Live trigger "Run radar now" → watch Inngest trace → new signal + counter-draft.
-- [ ] Approve counter-draft → W7 auto-spawns → 4 channel variants render.
+- [ ] Approve counter-draft → W7 auto-spawns → 3 channel variants render.
 - [ ] Click "Send today's brief now" → real Slack post → show jury Slack.
 
 **T+0 (post-demo):**

--- a/brand-intel/features/content-expansion.md
+++ b/brand-intel/features/content-expansion.md
@@ -17,7 +17,7 @@
 1. User reviews counter-draft у dashboard queue (W9 output, severity=high).
 2. Clicks **"Approve"** → status flips до `approved`. Toast "Approved + generating multi-channel..."
 3. **Auto-trigger** W7 Inngest function з `parent_counter_draft_id`.
-4. Within ~30s, 4 channel variants з'являються у "Multi-channel" section (під drafts queue):
+4. Within ~30s, 3 channel variants з'являються у "Multi-channel" section (під drafts queue):
    - Blog post (~800 words, з title)
    - X thread (5 tweets, як array у metadata)
    - LinkedIn post (~200 words)


### PR DESCRIPTION
## Summary
- Updates 5 brand-intel doc files (README, PIPELINES, ARCHITECTURE, RUNBOOK, features/content-expansion) щоб відповідати Wave 8 email channel deprecation.
- Замінює '4 channel variants (blog/X/LinkedIn/email)' → '3 channel variants (blog/X/LinkedIn)' усюди.

## Test plan
- [x] grep '4 channel|email subject' у brand-intel/ повертає 0 results
- [x] No code changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)