### PR TITLE
fix(tests): align content-variant tests з 3-channel W7

### DIFF
--- a/tests/schemas/content-variant.test.ts
+++ b/tests/schemas/content-variant.test.ts
@@ -47,19 +47,6 @@ function linkedinVariant() {
   };
 }
 
-function emailVariant() {
-  return {
-    channel: "email" as const,
-    title: null,
-    body: "Hi {{first_name}},\n\nQuick note on why our team picked Attio over HubSpot last month — flexibility was the deciding factor.",
-    metadata: {
-      subject: "Why we switched to Attio",
-      preheader: "Flexibility was the deciding factor.",
-    },
-    evidence_refs: ["draft-id"],
-  };
-}
-
 describe("ContentVariantSchema", () => {
   it("parses valid blog variant з proper metadata", () => {
     const parsed = ContentVariantSchema.parse(blogVariant());
@@ -96,18 +83,18 @@ describe("ContentVariantSchema", () => {
 });
 
 describe("ContentExpansionOutputSchema", () => {
-  it("parses output з all 4 channels", () => {
+  it("parses output з all 3 channels", () => {
     const parsed = ContentExpansionOutputSchema.parse({
       parent_counter_draft_id: PARENT_ID,
-      variants: [blogVariant(), xThreadVariant(), linkedinVariant(), emailVariant()],
+      variants: [blogVariant(), xThreadVariant(), linkedinVariant()],
     });
-    expect(parsed.variants).toHaveLength(4);
+    expect(parsed.variants).toHaveLength(3);
   });
 
-  it("rejects output з only 3 variants", () => {
+  it("rejects output з only 2 variants", () => {
     const result = ContentExpansionOutputSchema.safeParse({
       parent_counter_draft_id: PARENT_ID,
-      variants: [blogVariant(), xThreadVariant(), linkedinVariant()],
+      variants: [blogVariant(), xThreadVariant()],
     });
     expect(result.success).toBe(false);
   });
@@ -115,7 +102,7 @@ describe("ContentExpansionOutputSchema", () => {
   it("rejects output з duplicate channel", () => {
     const result = ContentExpansionOutputSchema.safeParse({
       parent_counter_draft_id: PARENT_ID,
-      variants: [blogVariant(), blogVariant(), linkedinVariant(), emailVariant()],
+      variants: [blogVariant(), blogVariant(), linkedinVariant()],
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Summary
Fixes CI test failure від Wave 8 (commit e1f6122) — `pnpm test` гейт було пропущено перед merge. Tests у `tests/schemas/content-variant.test.ts` ще очікували 4 channels + email helper.

## Changes
- Видалено `emailVariant()` helper
- "all 4 channels" assertion → "all 3 channels" + `toHaveLength(3)`
- "only 3 variants" reject test → "only 2 variants" (нижня межа під `.length(3)`)
- Duplicate-channel test без email refs

## Test plan
- [x] Local: `pnpm test` → 59/59 passed
- [x] Local: `pnpm typecheck` clean
- [x] CI ре-run на цьому branch має pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)