### PR TITLE
feat: Wave 9b — cost ledger fix (pre-create runs row + thread runId)

### DIFF
--- a/inngest/functions/competitor-radar.ts
+++ b/inngest/functions/competitor-radar.ts
@@ -102,6 +102,54 @@ export const competitorRadar = inngest.createFunction(
     const startedAt = new Date();
     const { organization_id } = event.data;
 
+    // 0. Create run row рано — щоб усі subsequent external API calls
+    //    могли тегувати cost_ledger rows з run_id. Без цього sumRunCost(runId)
+    //    повертає 0 бо recordCost пише з null run_id.
+    //    Initial stats — placeholder; finalize-run UPDATE'ить наприкінці.
+    const runId = (await step.run("create-run", async () => {
+      const supabase = createServiceClient() as unknown as {
+        from: (table: string) => {
+          insert: (row: Record<string, unknown>) => {
+            select: (cols: string) => {
+              single: () => Promise<{
+                data: { id: string } | null;
+                error: { message: string } | null;
+              }>;
+            };
+          };
+        };
+      };
+      const placeholderStats = RadarRunStatsSchema.parse({
+        function_name: "competitor-radar" as const,
+        started_at: startedAt.toISOString(),
+        duration_seconds: 0,
+        sources_scanned: 0,
+        signals_total: 0,
+        signals_by_severity: { high: 0, med: 0, low: 0 },
+        drafts_generated: 0,
+        cost_usd_cents: 0,
+      });
+      // ok=true як placeholder — finalize-run overwrites з real value.
+      // На pipeline crash row stays stale-true (rare; Inngest retries cover).
+      const { data, error } = await supabase
+        .from("runs")
+        .insert({
+          organization_id,
+          function_name: "competitor-radar",
+          event_payload: event.data as unknown as Record<string, unknown>,
+          ok: true,
+          started_at: startedAt.toISOString(),
+          finished_at: null,
+          stats: placeholderStats as unknown as Record<string, unknown>,
+        })
+        .select("id")
+        .single();
+      if (error || !data) {
+        throw new Error(`[create-run] insert failed: ${error?.message ?? "no row"}`);
+      }
+      return data.id;
+    })) as string;
+
     // 1. Load competitors -----------------------------------------------------
     const competitors = (await step.run("load-competitors", async () => {
       const supabase = createServiceClient();
@@ -184,6 +232,7 @@ export const competitorRadar = inngest.createFunction(
               query,
               max_results: TAVILY_RESULTS_PER_QUERY,
               organization_id,
+              run_id: runId,
             });
             for (const r of res.results) {
               collected.push({
@@ -286,6 +335,7 @@ export const competitorRadar = inngest.createFunction(
           schemaDescription: "W9 competitor radar signal classification",
           maxTokens: 600,
           temperature: 0.2,
+          run_id: runId,
         });
 
         out.push({
@@ -372,6 +422,7 @@ export const competitorRadar = inngest.createFunction(
           schemaName: "CounterDraft",
           maxTokens: 800,
           temperature: 0.3,
+          run_id: runId,
         });
 
         // Force evidence_refs to spec'd values (LLM may drift).
@@ -426,22 +477,12 @@ export const competitorRadar = inngest.createFunction(
       };
     })) as ReturnType<typeof RadarRunStatsSchema.parse>;
 
-    // 10. Persist run --------------------------------------------------------
-    // Note: `as any` cast on supabase client mirrors lib/services/cost.ts —
-    // generated Database types treat jsonb columns as `Json` (recursive union)
-    // which TS can't reconcile with stricter Zod-parsed objects. Drop the
-    // cast post `pnpm types:gen` if the types tighten.
-    const runId = (await step.run("persist-run", async () => {
+    // 10. Finalize run --------------------------------------------------------
+    // Run row already exists (created on step 0). Sum cost з cost_ledger
+    // (rows tagged з runId) → UPDATE row з final stats + ok=true + finished_at.
+    await step.run("finalize-run", async () => {
       const supabase = createServiceClient() as unknown as {
         from: (table: string) => {
-          insert: (row: Record<string, unknown>) => {
-            select: (cols: string) => {
-              single: () => Promise<{
-                data: { id: string } | null;
-                error: { message: string } | null;
-              }>;
-            };
-          };
           update: (row: Record<string, unknown>) => {
             eq: (
               col: string,
@@ -450,41 +491,23 @@ export const competitorRadar = inngest.createFunction(
           };
         };
       };
-      const { data: inserted, error: insErr } = await supabase
-        .from("runs")
-        .insert({
-          organization_id,
-          function_name: "competitor-radar",
-          event_payload: event.data as unknown as Record<string, unknown>,
-          ok: true,
-          started_at: startedAt.toISOString(),
-          finished_at: finishedAt.toISOString(),
-          stats: RadarRunStatsSchema.parse(stats) as unknown as Record<
-            string,
-            unknown
-          >,
-        })
-        .select("id")
-        .single();
-      if (insErr || !inserted) {
-        throw new Error(`[persist-run] insert failed: ${insErr?.message ?? "no row"}`);
-      }
-      const id = inserted.id;
-
-      const cost = await sumRunCost(id);
+      const cost = await sumRunCost(runId);
       const finalStats = RadarRunStatsSchema.parse({
         ...stats,
         cost_usd_cents: cost,
       });
       const { error: updErr } = await supabase
         .from("runs")
-        .update({ stats: finalStats as unknown as Record<string, unknown> })
-        .eq("id", id);
+        .update({
+          ok: true,
+          finished_at: finishedAt.toISOString(),
+          stats: finalStats as unknown as Record<string, unknown>,
+        })
+        .eq("id", runId);
       if (updErr) {
-        throw new Error(`[persist-run] cost update failed: ${updErr.message}`);
+        throw new Error(`[finalize-run] update failed: ${updErr.message}`);
       }
-      return id;
-    })) as string;
+    });
 
     return {
       run_id: runId,

--- a/inngest/functions/content-expand.ts
+++ b/inngest/functions/content-expand.ts
@@ -56,6 +56,49 @@ export const contentExpand = inngest.createFunction(
     const startedAt = new Date();
     const { organization_id, parent_counter_draft_id } = event.data;
 
+    // 0. Create run row рано — щоб усі subsequent LLM calls тегували cost_ledger
+    //    rows з run_id. finalize-run наприкінці UPDATE'ить ok/finished/stats.
+    const runId = (await step.run("create-run", async () => {
+      const supabase = createServiceClient() as unknown as {
+        from: (table: string) => {
+          insert: (row: Record<string, unknown>) => {
+            select: (cols: string) => {
+              single: () => Promise<{
+                data: { id: string } | null;
+                error: { message: string } | null;
+              }>;
+            };
+          };
+        };
+      };
+      const placeholderStats = ContentExpandRunStatsSchema.parse({
+        function_name: "content-expand" as const,
+        started_at: startedAt.toISOString(),
+        duration_seconds: 0,
+        parent_counter_draft_id,
+        variants_generated: 0,
+        cost_usd_cents: 0,
+      });
+      // ok=true як placeholder — finalize-run overwrites з real value.
+      const { data, error } = await supabase
+        .from("runs")
+        .insert({
+          organization_id,
+          function_name: "content-expand",
+          event_payload: event.data as unknown as Record<string, unknown>,
+          ok: true,
+          started_at: startedAt.toISOString(),
+          finished_at: null,
+          stats: placeholderStats as unknown as Record<string, unknown>,
+        })
+        .select("id")
+        .single();
+      if (error || !data) {
+        throw new Error(`[create-run] insert failed: ${error?.message ?? "no row"}`);
+      }
+      return data.id;
+    })) as string;
+
     // 1. Load counter-draft + parent brand display name ------------------------
     const counterDraft = (await step.run("load-counter-draft", async () => {
       const supabase = createServiceClient();
@@ -139,6 +182,7 @@ export const contentExpand = inngest.createFunction(
         schemaName: "BlogVariant",
         maxTokens: 2400,
         temperature: 0.5,
+        run_id: runId,
       });
       return ContentVariantSchema.parse({
         channel: "blog",
@@ -170,6 +214,7 @@ export const contentExpand = inngest.createFunction(
         schemaName: "XThreadVariant",
         maxTokens: 1200,
         temperature: 0.6,
+        run_id: runId,
       });
       return ContentVariantSchema.parse({
         channel: "x_thread",
@@ -198,6 +243,7 @@ export const contentExpand = inngest.createFunction(
         schemaName: "LinkedInVariant",
         maxTokens: 900,
         temperature: 0.5,
+        run_id: runId,
       });
       return ContentVariantSchema.parse({
         channel: "linkedin",
@@ -246,11 +292,14 @@ export const contentExpand = inngest.createFunction(
       }
     });
 
-    // 7. Persist run row -----------------------------------------------------
+    // 7. Finalize run row ----------------------------------------------------
+    // Run row already exists (created on step 0). Sum cost з cost_ledger
+    // (rows tagged з runId) → UPDATE row з final stats + ok + finished.
     const finishedAt = new Date();
-    const runId = await step.run("persist-run", async () => {
+    await step.run("finalize-run", async () => {
       const supabase = createServiceClient();
-      const baseStats = {
+      const cost = await sumRunCost(runId);
+      const finalStats = ContentExpandRunStatsSchema.parse({
         function_name: "content-expand" as const,
         started_at: startedAt.toISOString(),
         duration_seconds: Math.max(
@@ -259,42 +308,19 @@ export const contentExpand = inngest.createFunction(
         ),
         parent_counter_draft_id,
         variants_generated: variants.length,
-        cost_usd_cents: 0,
-      };
-
-      const { data: inserted, error: insErr } = await supabase
-        .from("runs")
-        .insert({
-          organization_id,
-          function_name: "content-expand",
-          event_payload: event.data as unknown as Json,
-          ok: true,
-          started_at: startedAt.toISOString(),
-          finished_at: finishedAt.toISOString(),
-          stats: ContentExpandRunStatsSchema.parse(baseStats) as unknown as Json,
-        })
-        .select("id")
-        .single();
-      if (insErr || !inserted) {
-        throw new Error(
-          `[persist-run] insert failed: ${insErr?.message ?? "no row"}`,
-        );
-      }
-      const id = (inserted as { id: string }).id;
-
-      const cost = await sumRunCost(id);
-      const finalStats = ContentExpandRunStatsSchema.parse({
-        ...baseStats,
         cost_usd_cents: cost,
       });
       const { error: updErr } = await supabase
         .from("runs")
-        .update({ stats: finalStats as unknown as Json })
-        .eq("id", id);
+        .update({
+          ok: true,
+          finished_at: finishedAt.toISOString(),
+          stats: finalStats as unknown as Json,
+        })
+        .eq("id", runId);
       if (updErr) {
-        throw new Error(`[persist-run] cost update failed: ${updErr.message}`);
+        throw new Error(`[finalize-run] update failed: ${updErr.message}`);
       }
-      return id;
     });
 
     return {

--- a/inngest/functions/morning-brief.ts
+++ b/inngest/functions/morning-brief.ts
@@ -100,6 +100,29 @@ export async function __morningBriefHandler({
     const { organization_id, run_window_start, call_preference } = event.data;
 
     // -----------------------------------------------------------------------
+    // 0a. create-run-row — рано щоб LLM/external calls могли тегувати cost_ledger.
+    // -----------------------------------------------------------------------
+    // ok=true як placeholder — finalize-run overwrites з real value.
+    const runId = (await step.run("create-run-row", async () => {
+      const supabase = createServiceClient();
+      const { data, error } = await supabase
+        .from("runs")
+        .insert({
+          organization_id,
+          function_name: "morning-brief",
+          event_payload: event.data as unknown as Json,
+          ok: true,
+          started_at: startedAt,
+        })
+        .select("id")
+        .single();
+      if (error || !data) {
+        throw new Error(`[create-run-row] insert failed: ${error?.message ?? "no row"}`);
+      }
+      return (data as { id: string }).id;
+    })) as string;
+
+    // -----------------------------------------------------------------------
     // 0. warn-voice-deferred — voice paths are deferred; fall through до markdown.
     // -----------------------------------------------------------------------
     if (call_preference !== "markdown") {
@@ -238,6 +261,7 @@ export async function __morningBriefHandler({
         operation: "morning-brief:synthesize",
         schemaName: "MorningBrief",
         temperature: 0.4,
+        run_id: runId,
       });
 
       // Defensive: ensure evidence_refs not empty (LLM might drop them) and
@@ -331,29 +355,11 @@ export async function __morningBriefHandler({
     });
 
     // -----------------------------------------------------------------------
-    // 6. persist-run — create runs row with finished stats in one shot.
+    // 6. finalize-run — UPDATE existing row з final stats + ok + finished_at.
     // -----------------------------------------------------------------------
-    const runId = await step.run("persist-run", async () => {
+    await step.run("finalize-run", async () => {
       const supabase = createServiceClient();
-      // Insert preliminary row to obtain run_id, then sum its cost.
-      const { data: created, error: createErr } = await supabase
-        .from("runs")
-        .insert({
-          organization_id,
-          function_name: "morning-brief",
-          event_payload: event.data as unknown as Json,
-          ok: sendResult.ok,
-          reason: sendResult.ok
-            ? `slack delivered ${brief.signal_count} signal${brief.signal_count === 1 ? "" : "s"}`
-            : `slack send failed: ${sendResult.error_reason}`,
-          started_at: startedAt,
-          finished_at: new Date().toISOString(),
-        })
-        .select("id")
-        .single();
-      if (createErr) throw createErr;
-
-      const cost_usd_cents = await sumRunCost(created.id);
+      const cost_usd_cents = await sumRunCost(runId);
       const stats = MorningBriefRunStatsSchema.parse({
         function_name: "morning-brief",
         started_at: startedAt,
@@ -366,11 +372,16 @@ export async function __morningBriefHandler({
 
       const { error: updErr } = await supabase
         .from("runs")
-        .update({ stats: stats as unknown as Json })
-        .eq("id", created.id);
+        .update({
+          ok: sendResult.ok,
+          reason: sendResult.ok
+            ? `slack delivered ${brief.signal_count} signal${brief.signal_count === 1 ? "" : "s"}`
+            : `slack send failed: ${sendResult.error_reason}`,
+          finished_at: new Date().toISOString(),
+          stats: stats as unknown as Json,
+        })
+        .eq("id", runId);
       if (updErr) throw updErr;
-
-      return created.id;
     });
 
     // run_window_start is part of contract; surface it in the structured log

--- a/inngest/functions/narrative-simulator.ts
+++ b/inngest/functions/narrative-simulator.ts
@@ -147,6 +147,27 @@ export async function __narrativeSimulatorHandler({
     } = event.data;
 
     // -----------------------------------------------------------------------
+    // 0. create-run-row — рано щоб LLM steps могли тегувати cost_ledger з runId
+    // -----------------------------------------------------------------------
+    // ok=true як placeholder — finalize-run overwrites з real value.
+    const runRow = await step.run("create-run-row", async () => {
+      const supabase = createServiceClient();
+      const { data, error } = await supabase
+        .from("runs")
+        .insert({
+          organization_id,
+          function_name: "narrative-simulator",
+          event_payload: event.data as unknown as Json,
+          ok: true,
+          started_at: startedAt,
+        })
+        .select("id")
+        .single();
+      if (error) throw error;
+      return data;
+    });
+
+    // -----------------------------------------------------------------------
     // 1. gather-context
     // -----------------------------------------------------------------------
     const context = await step.run("gather-context", async () => {
@@ -225,6 +246,7 @@ export async function __narrativeSimulatorHandler({
         operation: "narrative-simulator:generate",
         schemaName: "SimulatorOutput",
         temperature: 0.7,
+        run_id: runRow.id,
       });
 
       return object;
@@ -264,6 +286,7 @@ export async function __narrativeSimulatorHandler({
               operation: "narrative-simulator:score-openai",
               schemaName: "BrandRanking",
               temperature: 0,
+              run_id: runRow.id,
             }),
             generateObjectAnthropic<BrandRanking>({
               schema: BrandRankingSchema,
@@ -273,6 +296,7 @@ export async function __narrativeSimulatorHandler({
               operation: "narrative-simulator:score-anthropic",
               schemaName: "BrandRanking",
               temperature: 0,
+              run_id: runRow.id,
             }),
           ]);
 
@@ -302,27 +326,7 @@ export async function __narrativeSimulatorHandler({
     });
 
     // -----------------------------------------------------------------------
-    // 4. persist-run (placeholder row first so narrative_variants FK satisfied)
-    // -----------------------------------------------------------------------
-    const runRow = await step.run("create-run-row", async () => {
-      const supabase = createServiceClient();
-      const { data, error } = await supabase
-        .from("runs")
-        .insert({
-          organization_id,
-          function_name: "narrative-simulator",
-          event_payload: event.data as unknown as Json,
-          ok: true,
-          started_at: startedAt,
-        })
-        .select("id")
-        .single();
-      if (error) throw error;
-      return data;
-    });
-
-    // -----------------------------------------------------------------------
-    // 5. persist-variants
+    // 4. persist-variants
     // -----------------------------------------------------------------------
     const persistedCount = await step.run("persist-variants", async () => {
       const supabase = createServiceClient();


### PR DESCRIPTION
## Summary
Виправляє broken cost aggregation. Раніше `recordCost` писав rows з `run_id=null` бо runId створювався тільки наприкінці pipeline. `sumRunCost(runId)` → 0 → \"Today's spend\" = \$0.00 завжди.

## Changes (CRITICAL zone)
- **W9** competitor-radar: `create-run` step 0 → tavily/anthropic LLM calls тегують runId → `finalize-run` UPDATE
- **W7** content-expand: same pattern → blog (Anthropic) + X/LinkedIn (OpenAI) usage tagged
- **W5** narrative-simulator: `create-run-row` перенесено з кроку 4 на 0 → generate + score calls tagged
- **W6′** morning-brief: same pattern, finalize-run preserves real `sendResult.ok`

## Verification
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 59/59
- [x] `pnpm build` success
- [x] code-reviewer agent pass (one minor non-blocking inconsistency у W5/W6′ stats placeholder)
- [ ] Post-deploy: trigger W9 → AuditPanel cost > \$0.00; Operations tab Today's spend breakdown

## Risk
Pipeline crash між create-run і finalize-run leaves row з `ok=true` placeholder false-positive (rare bo Inngest retries cover). Schemas/events/migrations unchanged — clean rollback via revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)