### PR TITLE
feat: Wave 12 — per-prompt Peec signals (auto-scales to 50 prompts)

### DIFF
--- a/evals/brand-voice-judge.ts
+++ b/evals/brand-voice-judge.ts
@@ -1,0 +1,79 @@
+// Layer 2 — LLM-as-judge brand voice + diversity rubric.
+//
+// One Claude Sonnet 4.5 call with all variants embedded. The judge sees brand
+// voice rules from knowledge/brand-voice/knowledge.md plus the workspace
+// anti-AI style guidance, and returns a structured rubric verdict.
+
+import type { EvalVariant, JudgeReport } from "./lib/types";
+import { JudgeReportSchema } from "./lib/types";
+import { evalGenerateObjectAnthropic } from "./lib/llm";
+
+const SYSTEM_PROMPT = [
+  "You are a senior brand-voice editor evaluating counter-narrative variants for Attio (own brand, B2B CRM).",
+  "Competitors: HubSpot, Salesforce, Pipedrive, Zoho, Monday.",
+  "",
+  "Brand voice (per knowledge/brand-voice/knowledge.md and workspace rules):",
+  '- Pillar: "confident-builder" — direct, specific, opinionated, never preachy.',
+  "- Prose over bullets. Concrete numbers and product details over abstractions.",
+  "- Opinions over option-lists. Recommend, do not enumerate.",
+  "- Human-detectable writing. The reader should not suspect an LLM wrote this.",
+  "- Counter-drafts: ≤280 chars for X, ≤1300 for LinkedIn. No exaggerated claims, PII, politics, or disparagement.",
+  "",
+  "Forbidden words and AI-trope phrases (each instance is a clear violation):",
+  '- Words: "leverage", "streamline", "empower", "delve", "robust", "seamless", "navigate", "tapestry", "beacon", "synergy", "unleash", "revolutionize", "game-changer", "cutting-edge", "best-in-class", "world-class".',
+  '- Phrases: "we believe", "we focus on", "we prioritize", "settle for", "the status quo", "the truth is", "build your business", "with confidence", "make every interaction meaningful", "in a landscape where", "elevate your", "rather than settling".',
+  "",
+  "When you score a variant, deduct points for: forbidden words, AI tropes, generic claims without specifics (no product detail / no number / no concrete outcome), preachy or condescending tone, and structural sameness with sibling variants.",
+  "Diversity is judged at the SET level — how meaningfully the variants differ in angle (data model vs ergonomics vs price vs migration vs API), not just in which competitor they name.",
+].join("\n");
+
+function buildPrompt(brand_name: string, variants: EvalVariant[]): string {
+  const blocks = variants
+    .map(
+      (v, i) =>
+        `Variant ${i} (rank ${v.rank}, score ${v.score.toFixed(2)}, mention_rate ${v.mention_rate.toFixed(2)}, avg_position ${v.avg_position ?? "null"}):\n"""\n${v.body}\n"""`,
+    )
+    .join("\n\n");
+
+  return [
+    `Brand under evaluation: ${brand_name}.`,
+    `Total variants: ${variants.length}. Variants are ALL responses to the same competitor-move seed — they are supposed to be ranked alternatives, not duplicates.`,
+    "",
+    blocks,
+    "",
+    "Score each variant's brand_voice_fit on a 1-5 integer scale:",
+    "  1 = severe brand violations or AI slop; 2 = multiple violations; 3 = mediocre; 4 = good; 5 = exemplary.",
+    "List concrete violations per variant (forbidden words, AI tropes, vague claims). Empty array if none.",
+    "",
+    "Score the SET diversity on a 1-5 integer scale:",
+    "  1 = near-duplicates; 2 = same template, swapped competitor names; 3 = different angles but similar structure; 4 = three distinct angles; 5 = three distinct angles AND distinct rhetorical structures.",
+    "",
+    "Identify worst_offender_idx = the variant_idx that hurts the set the most.",
+    "Provide top_fix: ONE concrete instruction the engineer should apply to the simulator prompt to fix the highest-priority issue. Be specific and actionable.",
+  ].join("\n");
+}
+
+export interface RunJudgeOptions {
+  brand_name: string;
+  variants: EvalVariant[];
+  model?: "claude-sonnet-4-5" | "claude-haiku-4-5-20251001";
+}
+
+export async function runBrandVoiceJudge(
+  opts: RunJudgeOptions,
+): Promise<JudgeReport> {
+  const model = opts.model ?? "claude-sonnet-4-5";
+  const prompt = buildPrompt(opts.brand_name, opts.variants);
+
+  const { object } = await evalGenerateObjectAnthropic({
+    schema: JudgeReportSchema,
+    system: SYSTEM_PROMPT,
+    prompt,
+    model,
+    schemaName: "BrandVoiceJudgeReport",
+    temperature: 0,
+    maxTokens: 1500,
+  });
+
+  return object;
+}

--- a/evals/diversity.ts
+++ b/evals/diversity.ts
@@ -1,0 +1,202 @@
+// Layer 1 — deterministic diversity metrics for a set of W5 variants.
+//
+// No LLM calls. Pure string analysis. Designed to flag the homogeneity that a
+// human spotted in the screenshot: every variant opens with "competitor X
+// claims Y, but..." and pivots to "At Attio, we [pillar word]...".
+
+import type { DiversityReport, EvalVariant } from "./lib/types";
+
+// Forbidden phrases — sourced from the user's global anti-AI style rules
+// (~/.claude/CLAUDE.md "leverage / streamline / empower") plus the standard
+// LLM-trope dictionary that calibrates against Sonnet/Haiku/GPT outputs.
+const FORBIDDEN_PHRASES = [
+  "leverage",
+  "leveraging",
+  "streamline",
+  "streamlining",
+  "empower",
+  "empowering",
+  "empowers",
+  "delve",
+  "delves",
+  "delving",
+  "robust",
+  "seamless",
+  "seamlessly",
+  "navigate",
+  "navigating",
+  "tapestry",
+  "beacon",
+  "synergy",
+  "synergies",
+  "synergistic",
+  "unleash",
+  "unleashes",
+  "unleashing",
+  "revolutioniz", // catches revolutionize / revolutionizing / revolutionizes
+  "game-chang", // catches game-changer / game-changing
+  "cutting-edge",
+  "best-in-class",
+  "world-class",
+  "next-level",
+  "stand out from the crowd",
+  "in today's fast-paced",
+  "in the ever-evolving",
+];
+
+// AI sales-pitch templates that appear when a model is asked to "write
+// brand-voiced counter-narrative" without diversity hints. These all show up
+// in the screenshot fixture.
+const AI_TROPE_PHRASES = [
+  "we believe",
+  "we focus on",
+  "we prioritize",
+  "we empower",
+  "we deliver",
+  "settle for",
+  "settling for",
+  "the status quo",
+  "the truth is",
+  "build the future",
+  "build your business",
+  "with confidence",
+  "true power",
+  "make every interaction",
+  "meaningful and impactful",
+  "elevate your",
+  "thrive with it",
+  "in a landscape where",
+  "rather than settling",
+];
+
+// Tokenise to lowercase word array (alphanumerics only). Drops punctuation so
+// trigrams ignore commas / apostrophes that would otherwise inflate diversity.
+function tokenise(s: string): string[] {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s'-]/gu, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function ngrams(tokens: string[], n: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i + n <= tokens.length; i++) {
+    out.push(tokens.slice(i, i + n).join(" "));
+  }
+  return out;
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let intersect = 0;
+  for (const item of a) if (b.has(item)) intersect++;
+  return intersect / (a.size + b.size - intersect);
+}
+
+function findMatches(body: string, dictionary: string[]): string[] {
+  const lower = body.toLowerCase();
+  const hits = new Set<string>();
+  for (const phrase of dictionary) {
+    if (lower.includes(phrase)) hits.add(phrase);
+  }
+  return Array.from(hits).sort();
+}
+
+const STRUCTURAL_PATTERN =
+  /\b(but|however|while|though|whereas|yet)\b[\s\S]{0,400}?\bAt\s+Attio\b/i;
+
+export function computeDiversity(variants: EvalVariant[]): DiversityReport {
+  const n = variants.length;
+
+  // 1. Opening n-gram (first 8 tokens, case-folded).
+  const openings = variants.map((v) => tokenise(v.body).slice(0, 8).join(" "));
+  const opening_unique_ratio = new Set(openings).size / Math.max(1, n);
+
+  // 2. Pairwise trigram Jaccard.
+  const trigramSets = variants.map(
+    (v) => new Set(ngrams(tokenise(v.body), 3)),
+  );
+  const pairwise: number[] = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      pairwise.push(jaccard(trigramSets[i], trigramSets[j]));
+    }
+  }
+  const trigram_jaccard_pairwise_avg =
+    pairwise.length === 0
+      ? 0
+      : pairwise.reduce((a, b) => a + b, 0) / pairwise.length;
+  const trigram_jaccard_max = pairwise.length === 0 ? 0 : Math.max(...pairwise);
+
+  // 3. Forbidden phrase scan (per variant).
+  const forbidden_hits = variants.map((v, i) => ({
+    variant_idx: i,
+    matches: findMatches(v.body, FORBIDDEN_PHRASES),
+  }));
+
+  // 4. AI trope scan (per variant).
+  const ai_trope_hits = variants.map((v, i) => ({
+    variant_idx: i,
+    matches: findMatches(v.body, AI_TROPE_PHRASES),
+  }));
+
+  // 5. Structural pattern: "but/however/while ... At Attio".
+  const structural_pattern_count = variants.filter((v) =>
+    STRUCTURAL_PATTERN.test(v.body),
+  ).length;
+
+  // 6. Length CV.
+  const lengths = variants.map((v) => v.body.length);
+  const mean = lengths.reduce((a, b) => a + b, 0) / Math.max(1, lengths.length);
+  const variance =
+    lengths.reduce((acc, l) => acc + (l - mean) ** 2, 0) /
+    Math.max(1, lengths.length);
+  const length_cv = mean === 0 ? 0 : Math.sqrt(variance) / mean;
+
+  // 7. Build human-readable flags.
+  const flags: string[] = [];
+  if (opening_unique_ratio < 1) {
+    flags.push(
+      `Repeated opening n-gram across ${n - new Set(openings).size + 0} variant pair(s)`,
+    );
+  }
+  if (trigram_jaccard_pairwise_avg > 0.3) {
+    flags.push(
+      `High trigram overlap (avg ${trigram_jaccard_pairwise_avg.toFixed(2)} > 0.30 threshold)`,
+    );
+  }
+  const totalForbidden = forbidden_hits.reduce(
+    (a, h) => a + h.matches.length,
+    0,
+  );
+  if (totalForbidden > 0) {
+    flags.push(`${totalForbidden} forbidden-phrase hit(s) across variants`);
+  }
+  const totalTropes = ai_trope_hits.reduce((a, h) => a + h.matches.length, 0);
+  if (totalTropes > 0) {
+    flags.push(`${totalTropes} AI-trope hit(s) across variants`);
+  }
+  if (structural_pattern_count >= 2) {
+    flags.push(
+      `${structural_pattern_count}/${n} variants share "but…At Attio" structure`,
+    );
+  }
+  if (length_cv < 0.1 && n > 1) {
+    flags.push(
+      `Length variance suspiciously uniform (CV ${length_cv.toFixed(3)} < 0.10)`,
+    );
+  }
+
+  return {
+    variant_count: n,
+    opening_unique_ratio,
+    trigram_jaccard_pairwise_avg,
+    trigram_jaccard_max,
+    forbidden_hits,
+    ai_trope_hits,
+    structural_pattern_count,
+    length_cv,
+    flags,
+  };
+}

--- a/evals/fixtures/contrast-variants.json
+++ b/evals/fixtures/contrast-variants.json
@@ -1,0 +1,19 @@
+{
+  "fixture_id": "contrast-variants",
+  "description": "Three contrast pairs for Layer 3 scoring sensitivity. Each pair feeds two bodies through the production scoring step; we then compare the resulting scores. If pairs that should differ in score (attio_vs_competitor, real_vs_gibberish) come out near-identical, that confirms the hypothesis that the ranking-prompt judges return the same Attio rank from brand knowledge regardless of variant body.",
+  "brand_name": "Attio",
+  "pairs": {
+    "identical": {
+      "a": "Attio is the modern CRM built for teams that treat customer relationships as their most valuable asset. With a flexible data model, real-time API, and best-in-class deduplication, Attio replaces the rigid record-keeping of Salesforce with a workspace your revenue team will actually want to open every morning. Migrate in days, not months, and start measuring pipeline velocity within the first week.",
+      "b": "Attio is the modern CRM built for teams that treat customer relationships as their most valuable asset. With a flexible data model, real-time API, and best-in-class deduplication, Attio replaces the rigid record-keeping of Salesforce with a workspace your revenue team will actually want to open every morning. Migrate in days, not months, and start measuring pipeline velocity within the first week."
+    },
+    "attio_vs_competitor": {
+      "a": "Attio is the modern CRM built for teams that treat customer relationships as their most valuable asset. With a flexible data model, real-time API, and best-in-class deduplication, Attio replaces the rigid record-keeping of Salesforce with a workspace your revenue team will actually want to open every morning. Migrate in days, not months, and start measuring pipeline velocity within the first week.",
+      "b": "Salesforce is the most trusted CRM platform on the market, with two decades of enterprise deployments behind it. Sales Cloud, Service Cloud, and Einstein AI form a unified suite that no challenger can match. For organizations that need governance, audit trails, and ecosystem reach, Salesforce remains the only credible choice — the AppExchange alone covers more integrations than every competing CRM combined."
+    },
+    "real_vs_gibberish": {
+      "a": "Attio gives B2B SaaS teams a CRM that finally fits how they actually sell. The data model is fully customizable, the API is real-time, and the workspace stays out of your way. Replace Salesforce in two weeks with zero data loss and a 40% reduction in admin overhead.",
+      "b": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    }
+  }
+}

--- a/evals/fixtures/screenshot-variants.json
+++ b/evals/fixtures/screenshot-variants.json
@@ -1,0 +1,37 @@
+{
+  "fixture_id": "screenshot-variants",
+  "description": "Three W5 variants captured from dashboard UI on 2026-04-25 (Attio vs HubSpot/Salesforce). All three show stylistically homogenous output, two sharing identical mention_rate and avg_position — the user-reported regression that triggered this eval suite.",
+  "brand_name": "Attio",
+  "variants": [
+    {
+      "rank": 1,
+      "body": "HubSpot's \"free forever\" model sounds appealing, but it often leads to frustration when users encounter hidden limitations. At Attio, we believe in transparency and value for your investment. Our CRM solution offers the advanced functionalities you need without unexpected constraints. We focus on delivering powerful automation and customization options that truly empower teams. Rather than settling for a free version that may not meet your needs, invest in a solution that builds your business with confidence and clarity.",
+      "score": 0.45,
+      "score_reasoning": "Captured from UI screenshot; production scoring step assigned this value based on 5 prompts × 2 models panel.",
+      "predicted_sentiment": "neutral",
+      "avg_position": 1.3,
+      "mention_rate": 0.6,
+      "evidence_refs": ["ui-screenshot-2026-04-25"]
+    },
+    {
+      "rank": 2,
+      "body": "Salesforce's claim as the '#1 AI CRM' is impressive, but the truth is that businesses need more than just claims—they need a solution that adapts to their unique workflows. At Attio, we prioritize flexibility and integration, allowing teams to harness the power of AI in a way that aligns with their specific goals. Our approach fosters collaboration across departments, ensuring that every interaction is meaningful and impactful. Don't just settle for the status quo; elevate your CRM experience with Attio and build the future of your customer relationships with confidence.",
+      "score": 0.45,
+      "score_reasoning": "Captured from UI screenshot; production scoring step assigned this value based on 5 prompts × 2 models panel.",
+      "predicted_sentiment": "neutral",
+      "avg_position": 1.3,
+      "mention_rate": 0.6,
+      "evidence_refs": ["ui-screenshot-2026-04-25"]
+    },
+    {
+      "rank": 3,
+      "body": "While Salesforce boasts a comprehensive AI CRM platform, businesses often struggle with the rigidity of such monolithic systems. At Attio, we empower teams with a flexible, best-of-breed approach, enabling seamless integration with specialized tools that enhance productivity and drive growth. Our user-friendly interface and customizable solutions cater to the unique needs of each organization, ensuring that you don't just adopt a CRM, but thrive with it. In a landscape where adaptability is key, choose Attio to build confidence in your business processes and foster genuine customer relationships.",
+      "score": 0.24,
+      "score_reasoning": "Captured from UI screenshot; production scoring step assigned this value based on 5 prompts × 2 models panel.",
+      "predicted_sentiment": "neutral",
+      "avg_position": 2.5,
+      "mention_rate": 0.6,
+      "evidence_refs": ["ui-screenshot-2026-04-25"]
+    }
+  ]
+}

--- a/evals/lib/llm.ts
+++ b/evals/lib/llm.ts
@@ -1,0 +1,74 @@
+// Lightweight LLM wrappers for eval scripts.
+//
+// We deliberately do NOT import lib/services/{openai,anthropic}.ts because
+// those are tagged "server-only" and write into the production cost ledger.
+// Evals are sandbox runs — they should not pollute org-level cost rows. We
+// call the AI SDK directly here. Keys come from .env.local (load via dotenv
+// in the runner before invoking these functions).
+
+import { anthropic } from "@ai-sdk/anthropic";
+import { openai } from "@ai-sdk/openai";
+import { generateObject } from "ai";
+import type { z } from "zod";
+
+export type OpenAIModel = "gpt-4o-mini" | "gpt-4o";
+export type AnthropicModel = "claude-sonnet-4-5" | "claude-haiku-4-5-20251001";
+
+interface BaseInput<T> {
+  schema: z.Schema<T, z.ZodTypeDef, unknown>;
+  prompt: string;
+  system?: string;
+  schemaName?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+interface OpenAIInput<T> extends BaseInput<T> {
+  model: OpenAIModel;
+}
+
+interface AnthropicInput<T> extends BaseInput<T> {
+  model: AnthropicModel;
+}
+
+export async function evalGenerateObjectOpenAI<T>(
+  input: OpenAIInput<T>,
+): Promise<{ object: T; usage: { totalTokens: number } }> {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("[evals/llm] OPENAI_API_KEY is not set");
+  }
+  const result = await generateObject({
+    model: openai(input.model),
+    schema: input.schema,
+    prompt: input.prompt,
+    system: input.system,
+    schemaName: input.schemaName,
+    temperature: input.temperature,
+    maxTokens: input.maxTokens,
+  });
+  return {
+    object: result.object as T,
+    usage: { totalTokens: result.usage.totalTokens },
+  };
+}
+
+export async function evalGenerateObjectAnthropic<T>(
+  input: AnthropicInput<T>,
+): Promise<{ object: T; usage: { totalTokens: number } }> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error("[evals/llm] ANTHROPIC_API_KEY is not set");
+  }
+  const result = await generateObject({
+    model: anthropic(input.model),
+    schema: input.schema,
+    prompt: input.prompt,
+    system: input.system,
+    schemaName: input.schemaName,
+    temperature: input.temperature,
+    maxTokens: input.maxTokens,
+  });
+  return {
+    object: result.object as T,
+    usage: { totalTokens: result.usage.totalTokens },
+  };
+}

--- a/evals/lib/scoring.ts
+++ b/evals/lib/scoring.ts
@@ -1,0 +1,67 @@
+// Scoring helpers — copied verbatim from inngest/functions/narrative-simulator.ts
+// (lines 60-141) so eval scripts can replicate the production score computation
+// without importing the server-only Inngest module.
+//
+// Keep in sync with the source. If the production formula changes, update this
+// file and re-run the sensitivity eval.
+
+/**
+ * Score formula per CONTRACTS.md §2.5:
+ *   score = mention_rate × (1 / avg_position), clamped to [0, 1].
+ *   avg_position = null  → score = 0 (brand never mentioned).
+ */
+export function computeScore(
+  mention_rate: number,
+  avg_position: number | null,
+): number {
+  if (avg_position === null) return 0;
+  const safePos = Math.max(1, avg_position);
+  const raw = mention_rate * (1 / safePos);
+  return Math.max(0, Math.min(1, raw));
+}
+
+/**
+ * 1-indexed position of a brand inside the ranked list. Case-insensitive
+ * substring match (e.g. "Attio CRM" still counts as Attio). Returns null if
+ * the brand is absent.
+ */
+export function findBrandPosition(
+  ranking: string[],
+  brand_name: string,
+): number | null {
+  const needle = brand_name.toLowerCase();
+  const idx = ranking.findIndex((name) => name.toLowerCase().includes(needle));
+  return idx === -1 ? null : idx + 1;
+}
+
+/**
+ * Aggregate per-prompt × per-model positions into mention_rate and
+ * avg_position. avg_position only averages runs that mentioned the brand.
+ */
+export function aggregateScores(positions: Array<number | null>): {
+  mention_rate: number;
+  avg_position: number | null;
+} {
+  if (positions.length === 0) return { mention_rate: 0, avg_position: null };
+  const mentions = positions.filter((p): p is number => p !== null);
+  const mention_rate = mentions.length / positions.length;
+  const avg_position =
+    mentions.length === 0
+      ? null
+      : mentions.reduce((acc, n) => acc + n, 0) / mentions.length;
+  return { mention_rate, avg_position };
+}
+
+/**
+ * Original 5 evergreen CRM-category probes used by the W5 simulator when the
+ * Peec snapshot has fewer than 3 prompts. These also serve as the canonical
+ * scoring set for the sensitivity eval — they are what production would use
+ * for an unseeded org.
+ */
+export const FALLBACK_SCORING_PROMPTS = [
+  "What are the top CRM platforms for high-growth startups in 2026?",
+  "Which modern CRM tools best handle relationship intelligence at scale?",
+  "List the leading alternatives to Salesforce for tech companies.",
+  "Which CRM platforms have the best data model for B2B SaaS teams?",
+  "Recommend a CRM with strong API and customization for product teams.",
+] as const;

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -1,0 +1,105 @@
+// Eval result types — shared across diversity / judge / sensitivity layers.
+import { z } from "zod";
+
+// Reusable narrative-variant shape. We don't import @/lib/schemas/narrative-variant
+// directly because that file is consumed by server-only code paths; instead we
+// mirror the public fields the eval needs. NB: production schema is the SSOT
+// for runtime validation — this is a strict subset for fixture parsing.
+export const EvalVariantSchema = z.object({
+  rank: z.number().int().min(1).max(5),
+  body: z.string().min(50).max(1500),
+  score: z.number().min(0).max(1),
+  score_reasoning: z.string().min(20),
+  predicted_sentiment: z.enum(["positive", "neutral", "negative"]),
+  avg_position: z.number().min(1).nullable(),
+  mention_rate: z.number().min(0).max(1),
+  evidence_refs: z.array(z.string()).min(1),
+});
+export type EvalVariant = z.infer<typeof EvalVariantSchema>;
+
+export const FixtureFileSchema = z.object({
+  fixture_id: z.string(),
+  description: z.string(),
+  brand_name: z.string(),
+  variants: z.array(EvalVariantSchema).min(1).max(5),
+});
+export type FixtureFile = z.infer<typeof FixtureFileSchema>;
+
+export const ContrastFixtureSchema = z.object({
+  fixture_id: z.literal("contrast-variants"),
+  description: z.string(),
+  brand_name: z.string(),
+  pairs: z.object({
+    identical: z.object({ a: z.string(), b: z.string() }),
+    attio_vs_competitor: z.object({ a: z.string(), b: z.string() }),
+    real_vs_gibberish: z.object({ a: z.string(), b: z.string() }),
+  }),
+});
+export type ContrastFixture = z.infer<typeof ContrastFixtureSchema>;
+
+// Layer 1 — diversity
+export interface DiversityReport {
+  variant_count: number;
+  opening_unique_ratio: number; // unique 8-token openings / N
+  trigram_jaccard_pairwise_avg: number;
+  trigram_jaccard_max: number;
+  forbidden_hits: Array<{ variant_idx: number; matches: string[] }>;
+  ai_trope_hits: Array<{ variant_idx: number; matches: string[] }>;
+  structural_pattern_count: number; // variants matching "but ... At Attio" template
+  length_cv: number; // stddev / mean
+  flags: string[]; // human-readable issue summary
+}
+
+// Layer 2 — LLM judge
+export const JudgeReportSchema = z.object({
+  diversity: z.object({
+    score: z.number().int().min(1).max(5),
+    reasoning: z.string().min(20),
+  }),
+  brand_voice_fit: z.array(
+    z.object({
+      variant_idx: z.number().int().min(0),
+      score: z.number().int().min(1).max(5),
+      violations: z.array(z.string()),
+    }),
+  ),
+  worst_offender_idx: z.number().int().min(0),
+  top_fix: z.string().min(20),
+});
+export type JudgeReport = z.infer<typeof JudgeReportSchema>;
+
+// Layer 3 — scoring sensitivity
+export interface ScoredVariant {
+  label: string;
+  body_preview: string;
+  positions: Array<number | null>;
+  mention_rate: number;
+  avg_position: number | null;
+  score: number;
+}
+
+export interface SensitivityCase {
+  case_id: "identical" | "attio_vs_competitor" | "real_vs_gibberish";
+  expectation: string; // human-readable expected outcome
+  a: ScoredVariant;
+  b: ScoredVariant;
+  delta_score: number;
+  delta_mention_rate: number;
+  flag: "pass" | "fail" | "warn";
+}
+
+export interface SensitivityReport {
+  cases: SensitivityCase[];
+  hypothesis_confirmed: boolean; // judges ignore body
+  total_llm_calls: number;
+}
+
+export interface FullEvalReport {
+  generated_at: string;
+  fixture_id: string;
+  brand_name: string;
+  layer_1: DiversityReport;
+  layer_2: JudgeReport | { skipped: string };
+  layer_3: SensitivityReport | { skipped: string };
+  top_fixes: string[];
+}

--- a/evals/reports/2026-04-26T04-52-29-805Z__screenshot-variants.md
+++ b/evals/reports/2026-04-26T04-52-29-805Z__screenshot-variants.md
@@ -1,0 +1,371 @@
+# BBH W5 evals report — 2026-04-26T04:52:29.805Z
+
+Fixture: `screenshot-variants` (Three W5 variants captured from dashboard UI on 2026-04-25 (Attio vs HubSpot/Salesforce). All three show stylistically homogenous output, two sharing identical mention_rate and avg_position — the user-reported regression that triggered this eval suite.)
+Brand: **Attio**
+Variants evaluated: 3
+
+---
+
+## Layer 1 — Deterministic diversity
+
+- variant_count: 3
+- opening_unique_ratio: 1.00 ✅ (1.0 = all openings unique)
+- trigram_jaccard_pairwise_avg: 0.008 ✅ (>0.30 = high overlap)
+- trigram_jaccard_max: 0.012 ✅
+- structural_pattern_count: 3/3 match `but…At Attio` template ❌
+- length_cv: 0.056 ❌ (low CV = uniform length)
+
+**Forbidden phrase hits:**
+- variant #0: empower ❌
+- variant #2: empower, seamless ❌
+
+**AI-trope hits:**
+- variant #0: rather than settling, settling for, we believe, we focus on, with confidence ❌
+- variant #1: build the future, elevate your, meaningful and impactful, settle for, the status quo, the truth is, we prioritize, with confidence ❌
+- variant #2: in a landscape where, thrive with it, we empower ❌
+
+**Flags:**
+- 3 forbidden-phrase hit(s) across variants
+- 16 AI-trope hit(s) across variants
+- 3/3 variants share "but…At Attio" structure
+- Length variance suspiciously uniform (CV 0.056 < 0.10)
+
+## Layer 2 — LLM brand-voice judge (claude-sonnet-4-5)
+
+- diversity: **2/5** — All three variants follow nearly identical templates: [Competitor claim] + [vague problem with competitor] + 'At Attio, we [abstract value prop]' + [generic benefits] + [preachy call-to-action]. Variant 0 targets HubSpot's freemium model, Variant 1 and 2 both target Salesforce (AI claims and monolithic rigidity respectively), but none explore distinct angles like data model flexibility, specific API capabilities, concrete migration paths, pricing transparency with numbers, or ergonomic product details. The rhetorical structure is identical across all three: problem-solution-CTA format with abstract language.
+
+**Brand voice fit per variant:**
+- variant #0: **1/5** — Forbidden phrase: 'we believe'; Forbidden phrase: 'We focus on'; Forbidden phrase: 'Rather than settling'; Forbidden phrase: 'builds your business with confidence'; Forbidden word: 'empower'; Generic claim without specifics: 'advanced functionalities' - no product detail or concrete feature; Generic claim: 'powerful automation and customization options' - no numbers, no specific capability; Preachy tone: 'invest in a solution that builds your business with confidence and clarity'; AI trope structure: multiple abstract value propositions without concrete evidence
+- variant #1: **1/5** — Forbidden phrase: 'the truth is'; Forbidden phrase: 'we prioritize'; Forbidden phrase: 'make every interaction meaningful' (variant: 'every interaction is meaningful'); Forbidden phrase: 'Don't just settle for the status quo'; Forbidden phrase: 'elevate your'; Forbidden phrase: 'build the future... with confidence'; Generic claim: 'flexibility and integration' - no specific product details; Generic claim: 'harness the power of AI' - no concrete feature or number; Preachy and condescending tone throughout; AI trope structure: abstract benefits without specifics
+- variant #2: **1/5** — Forbidden word: 'empower'; Forbidden word: 'seamless'; Forbidden word: 'best-of-breed' (variant of 'best-in-class'); Forbidden phrase: 'In a landscape where'; Forbidden phrase: 'build confidence'; Generic claim: 'flexible, best-of-breed approach' - no specifics; Generic claim: 'user-friendly interface and customizable solutions' - no product details or numbers; Preachy tone: 'don't just adopt a CRM, but thrive with it'; AI trope: 'foster genuine customer relationships' - vague abstraction
+
+- worst_offender_idx: **1**
+- top_fix: Add a hard constraint to the simulator prompt: 'Each variant must include at least one concrete product detail (specific feature name, number, API capability, or measurable outcome) and must NOT use any form of the phrases: we believe, we focus on, we prioritize, the truth is, settle for, the status quo, elevate your, with confidence, or build your business.' This will force specificity and eliminate the most egregious AI trope violations.
+
+## Layer 3 — Scoring sensitivity probe
+
+Total LLM calls: 40
+
+### Case: `identical` ✅
+Expectation: Δscore == 0 (deterministic with temp=0)
+
+| label | mention_rate | avg_position | score |
+|---|---|---|---|
+| identical.a | 0.60 | 1.00 | 0.600 |
+| identical.b | 0.60 | 1.00 | 0.600 |
+
+Δscore = 0.000 · Δmention_rate = 0.00
+
+### Case: `attio_vs_competitor` ✅
+Expectation: Δscore >> 0; Attio variant scores higher than competitor variant
+
+| label | mention_rate | avg_position | score |
+|---|---|---|---|
+| attio_vs_competitor.a | 0.60 | 1.00 | 0.600 |
+| attio_vs_competitor.b | 0.40 | 1.50 | 0.267 |
+
+Δscore = 0.333 · Δmention_rate = 0.20
+
+### Case: `real_vs_gibberish` ❌
+Expectation: Δscore >> 0; real Attio variant scores higher than lorem ipsum
+
+| label | mention_rate | avg_position | score |
+|---|---|---|---|
+| real_vs_gibberish.a | 0.60 | 1.33 | 0.450 |
+| real_vs_gibberish.b | 0.40 | 1.00 | 0.400 |
+
+Δscore = 0.050 · Δmention_rate = 0.20
+
+**Hypothesis CONFIRMED:** at least one contrast pair shows insufficient Δscore — judges are not sufficiently sensitive to variant body. Scoring methodology needs redesign.
+
+---
+
+## Recommended next-plan fixes
+
+1. Rewrite simulator prompt to require ANGLE diversity (e.g. data model vs migration cost vs API ergonomics vs price), not just N variants. Forbid the 'competitor X, but At Attio…' template.
+2. Add a forbidden-phrase post-filter before persist (or inject the list into the simulator prompt as 'NEVER use'). 3 forbidden + 16 trope hits this run.
+3. Replace the global ranking-prompt scoring with a body-relative metric (e.g. per-variant embedding similarity to brand voice corpus, or ask the judge to RATE the variant directly instead of re-ranking the brand list).
+4. Judge-recommended top fix: Add a hard constraint to the simulator prompt: 'Each variant must include at least one concrete product detail (specific feature name, number, API capability, or measurable outcome) and must NOT use any form of the phrases: we believe, we focus on, we prioritize, the truth is, settle for, the status quo, elevate your, with confidence, or build your business.' This will force specificity and eliminate the most egregious AI trope violations.
+
+---
+
+<details><summary>Raw report JSON</summary>
+
+```json
+{
+  "generated_at": "2026-04-26T04:52:29.805Z",
+  "fixture_id": "screenshot-variants",
+  "brand_name": "Attio",
+  "layer_1": {
+    "variant_count": 3,
+    "opening_unique_ratio": 1,
+    "trigram_jaccard_pairwise_avg": 0.008064082796000375,
+    "trigram_jaccard_max": 0.012195121951219513,
+    "forbidden_hits": [
+      {
+        "variant_idx": 0,
+        "matches": [
+          "empower"
+        ]
+      },
+      {
+        "variant_idx": 1,
+        "matches": []
+      },
+      {
+        "variant_idx": 2,
+        "matches": [
+          "empower",
+          "seamless"
+        ]
+      }
+    ],
+    "ai_trope_hits": [
+      {
+        "variant_idx": 0,
+        "matches": [
+          "rather than settling",
+          "settling for",
+          "we believe",
+          "we focus on",
+          "with confidence"
+        ]
+      },
+      {
+        "variant_idx": 1,
+        "matches": [
+          "build the future",
+          "elevate your",
+          "meaningful and impactful",
+          "settle for",
+          "the status quo",
+          "the truth is",
+          "we prioritize",
+          "with confidence"
+        ]
+      },
+      {
+        "variant_idx": 2,
+        "matches": [
+          "in a landscape where",
+          "thrive with it",
+          "we empower"
+        ]
+      }
+    ],
+    "structural_pattern_count": 3,
+    "length_cv": 0.05624144345280649,
+    "flags": [
+      "3 forbidden-phrase hit(s) across variants",
+      "16 AI-trope hit(s) across variants",
+      "3/3 variants share \"but…At Attio\" structure",
+      "Length variance suspiciously uniform (CV 0.056 < 0.10)"
+    ]
+  },
+  "layer_2": {
+    "diversity": {
+      "score": 2,
+      "reasoning": "All three variants follow nearly identical templates: [Competitor claim] + [vague problem with competitor] + 'At Attio, we [abstract value prop]' + [generic benefits] + [preachy call-to-action]. Variant 0 targets HubSpot's freemium model, Variant 1 and 2 both target Salesforce (AI claims and monolithic rigidity respectively), but none explore distinct angles like data model flexibility, specific API capabilities, concrete migration paths, pricing transparency with numbers, or ergonomic product details. The rhetorical structure is identical across all three: problem-solution-CTA format with abstract language."
+    },
+    "brand_voice_fit": [
+      {
+        "variant_idx": 0,
+        "score": 1,
+        "violations": [
+          "Forbidden phrase: 'we believe'",
+          "Forbidden phrase: 'We focus on'",
+          "Forbidden phrase: 'Rather than settling'",
+          "Forbidden phrase: 'builds your business with confidence'",
+          "Forbidden word: 'empower'",
+          "Generic claim without specifics: 'advanced functionalities' - no product detail or concrete feature",
+          "Generic claim: 'powerful automation and customization options' - no numbers, no specific capability",
+          "Preachy tone: 'invest in a solution that builds your business with confidence and clarity'",
+          "AI trope structure: multiple abstract value propositions without concrete evidence"
+        ]
+      },
+      {
+        "variant_idx": 1,
+        "score": 1,
+        "violations": [
+          "Forbidden phrase: 'the truth is'",
+          "Forbidden phrase: 'we prioritize'",
+          "Forbidden phrase: 'make every interaction meaningful' (variant: 'every interaction is meaningful')",
+          "Forbidden phrase: 'Don't just settle for the status quo'",
+          "Forbidden phrase: 'elevate your'",
+          "Forbidden phrase: 'build the future... with confidence'",
+          "Generic claim: 'flexibility and integration' - no specific product details",
+          "Generic claim: 'harness the power of AI' - no concrete feature or number",
+          "Preachy and condescending tone throughout",
+          "AI trope structure: abstract benefits without specifics"
+        ]
+      },
+      {
+        "variant_idx": 2,
+        "score": 1,
+        "violations": [
+          "Forbidden word: 'empower'",
+          "Forbidden word: 'seamless'",
+          "Forbidden word: 'best-of-breed' (variant of 'best-in-class')",
+          "Forbidden phrase: 'In a landscape where'",
+          "Forbidden phrase: 'build confidence'",
+          "Generic claim: 'flexible, best-of-breed approach' - no specifics",
+          "Generic claim: 'user-friendly interface and customizable solutions' - no product details or numbers",
+          "Preachy tone: 'don't just adopt a CRM, but thrive with it'",
+          "AI trope: 'foster genuine customer relationships' - vague abstraction"
+        ]
+      }
+    ],
+    "worst_offender_idx": 1,
+    "top_fix": "Add a hard constraint to the simulator prompt: 'Each variant must include at least one concrete product detail (specific feature name, number, API capability, or measurable outcome) and must NOT use any form of the phrases: we believe, we focus on, we prioritize, the truth is, settle for, the status quo, elevate your, with confidence, or build your business.' This will force specificity and eliminate the most egregious AI trope violations."
+  },
+  "layer_3": {
+    "cases": [
+      {
+        "case_id": "identical",
+        "expectation": "Δscore == 0 (deterministic with temp=0)",
+        "a": {
+          "label": "identical.a",
+          "body_preview": "Attio is the modern CRM built for teams that treat customer relationships as their most valuable asset. With a flexible ",
+          "positions": [
+            1,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1
+          ],
+          "mention_rate": 0.6,
+          "avg_position": 1,
+          "score": 0.6
+        },
+        "b": {
+          "label": "identical.b",
+          "body_preview": "Attio is the modern CRM built for teams that treat customer relationships as their most valuable asset. With a flexible ",
+          "positions": [
+            1,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1
+          ],
+          "mention_rate": 0.6,
+          "avg_position": 1,
+          "score": 0.6
+        },
+        "delta_score": 0,
+        "delta_mention_rate": 0,
+        "flag": "pass"
+      },
+      {
+        "case_id": "attio_vs_competitor",
+        "expectation": "Δscore >> 0; Attio variant scores higher than competitor variant",
+        "a": {
+          "label": "attio_vs_competitor.a",
+          "body_preview": "Attio is the modern CRM built for teams that treat customer relationships as their most valuable asset. With a flexible ",
+          "positions": [
+            1,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1
+          ],
+          "mention_rate": 0.6,
+          "avg_position": 1,
+          "score": 0.6
+        },
+        "b": {
+          "label": "attio_vs_competitor.b",
+          "body_preview": "Salesforce is the most trusted CRM platform on the market, with two decades of enterprise deployments behind it. Sales C",
+          "positions": [
+            null,
+            3,
+            null,
+            1,
+            null,
+            null,
+            null,
+            1,
+            null,
+            1
+          ],
+          "mention_rate": 0.4,
+          "avg_position": 1.5,
+          "score": 0.26666666666666666
+        },
+        "delta_score": 0.3333333333333333,
+        "delta_mention_rate": 0.19999999999999996,
+        "flag": "pass"
+      },
+      {
+        "case_id": "real_vs_gibberish",
+        "expectation": "Δscore >> 0; real Attio variant scores higher than lorem ipsum",
+        "a": {
+          "label": "real_vs_gibberish.a",
+          "body_preview": "Attio gives B2B SaaS teams a CRM that finally fits how they actually sell. The data model is fully customizable, the API",
+          "positions": [
+            3,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1,
+            null,
+            1
+          ],
+          "mention_rate": 0.6,
+          "avg_position": 1.3333333333333333,
+          "score": 0.44999999999999996
+        },
+        "b": {
+          "label": "real_vs_gibberish.b",
+          "body_preview": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliq",
+          "positions": [
+            null,
+            1,
+            null,
+            1,
+            null,
+            null,
+            null,
+            1,
+            null,
+            1
+          ],
+          "mention_rate": 0.4,
+          "avg_position": 1,
+          "score": 0.4
+        },
+        "delta_score": 0.04999999999999993,
+        "delta_mention_rate": 0.19999999999999996,
+        "flag": "fail"
+      }
+    ],
+    "hypothesis_confirmed": true,
+    "total_llm_calls": 40
+  },
+  "top_fixes": [
+    "Rewrite simulator prompt to require ANGLE diversity (e.g. data model vs migration cost vs API ergonomics vs price), not just N variants. Forbid the 'competitor X, but At Attio…' template.",
+    "Add a forbidden-phrase post-filter before persist (or inject the list into the simulator prompt as 'NEVER use'). 3 forbidden + 16 trope hits this run.",
+    "Replace the global ranking-prompt scoring with a body-relative metric (e.g. per-variant embedding similarity to brand voice corpus, or ask the judge to RATE the variant directly instead of re-ranking the brand list).",
+    "Judge-recommended top fix: Add a hard constraint to the simulator prompt: 'Each variant must include at least one concrete product detail (specific feature name, number, API capability, or measurable outcome) and must NOT use any form of the phrases: we believe, we focus on, we prioritize, the truth is, settle for, the status quo, elevate your, with confidence, or build your business.' This will force specificity and eliminate the most egregious AI trope violations."
+  ]
+}
+```
+
+</details>

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -1,0 +1,476 @@
+// CLI runner for the BBH W5 narrative-simulator eval suite.
+//
+// Usage:
+//   pnpm tsx evals/run-evals.ts                            # screenshot fixture, all 3 layers
+//   pnpm tsx evals/run-evals.ts --fixture=screenshot-variants
+//   pnpm tsx evals/run-evals.ts --run-id=<uuid>            # load N variants from Supabase
+//   pnpm tsx evals/run-evals.ts --no-judge --no-sensitivity # Layer 1 only
+//
+// Env: reads .env.local from the project root. Required keys depend on layers:
+//   - Layer 1 needs nothing.
+//   - Layer 2 needs ANTHROPIC_API_KEY.
+//   - Layer 3 needs OPENAI_API_KEY + ANTHROPIC_API_KEY.
+//   - --run-id needs NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runBrandVoiceJudge } from "./brand-voice-judge";
+import { computeDiversity } from "./diversity";
+import { runScoringSensitivity } from "./scoring-sensitivity";
+import {
+  ContrastFixtureSchema,
+  EvalVariantSchema,
+  FixtureFileSchema,
+  type ContrastFixture,
+  type DiversityReport,
+  type EvalVariant,
+  type FixtureFile,
+  type FullEvalReport,
+  type JudgeReport,
+  type SensitivityReport,
+} from "./lib/types";
+
+// ---------------------------------------------------------------------------
+// Paths + env
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const EVALS_DIR = dirname(__filename);
+const PROJECT_ROOT = resolve(EVALS_DIR, "..");
+const FIXTURES_DIR = resolve(EVALS_DIR, "fixtures");
+const REPORTS_DIR = resolve(EVALS_DIR, "reports");
+
+/**
+ * Tiny .env.local loader — avoids adding a `dotenv` dep just for this script.
+ * Lines are KEY=VALUE; quoted values stripped; '#' comments skipped.
+ */
+function loadEnvLocal(): void {
+  const envPath = resolve(PROJECT_ROOT, ".env.local");
+  let raw: string;
+  try {
+    raw = readFileSync(envPath, "utf8");
+  } catch {
+    console.warn(`[evals] .env.local not found at ${envPath}; relying on existing process.env`);
+    return;
+  }
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    // .env.local wins over inherited env — eval scripts always want the
+    // project-local key, not whatever happened to be in the shell.
+    process.env[key] = value;
+  }
+  console.error(
+    `[evals] env loaded from ${envPath} — OPENAI=${process.env.OPENAI_API_KEY ? "set" : "unset"}, ANTHROPIC=${process.env.ANTHROPIC_API_KEY ? "set" : "unset"}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+interface Args {
+  fixture: string;
+  runId: string | null;
+  skipJudge: boolean;
+  skipSensitivity: boolean;
+  contrastFixture: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    fixture: "screenshot-variants",
+    runId: null,
+    skipJudge: false,
+    skipSensitivity: false,
+    contrastFixture: "contrast-variants",
+  };
+  for (const arg of argv) {
+    if (arg.startsWith("--fixture=")) out.fixture = arg.slice("--fixture=".length);
+    else if (arg.startsWith("--run-id=")) out.runId = arg.slice("--run-id=".length);
+    else if (arg.startsWith("--contrast=")) out.contrastFixture = arg.slice("--contrast=".length);
+    else if (arg === "--no-judge") out.skipJudge = true;
+    else if (arg === "--no-sensitivity") out.skipSensitivity = true;
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else if (arg.startsWith("--")) {
+      console.warn(`[evals] unknown flag: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function printHelp(): void {
+  console.log(`Usage: pnpm tsx evals/run-evals.ts [options]
+
+Options:
+  --fixture=<name>      Load evals/fixtures/<name>.json (default: screenshot-variants)
+  --run-id=<uuid>       Instead of file, load narrative_variants for this simulator_run_id from Supabase
+  --contrast=<name>     Contrast pairs fixture for Layer 3 (default: contrast-variants)
+  --no-judge            Skip Layer 2 (Anthropic LLM judge)
+  --no-sensitivity      Skip Layer 3 (Anthropic + OpenAI scoring probe)
+  --help, -h            Show this help
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture / Supabase loaders
+// ---------------------------------------------------------------------------
+
+function loadFixtureFile(name: string): FixtureFile {
+  const path = resolve(FIXTURES_DIR, `${name}.json`);
+  const raw = readFileSync(path, "utf8");
+  const json: unknown = JSON.parse(raw);
+  return FixtureFileSchema.parse(json);
+}
+
+function loadContrastFixtureFile(name: string): ContrastFixture {
+  const path = resolve(FIXTURES_DIR, `${name}.json`);
+  const raw = readFileSync(path, "utf8");
+  const json: unknown = JSON.parse(raw);
+  return ContrastFixtureSchema.parse(json);
+}
+
+async function loadFromSupabase(run_id: string): Promise<FixtureFile> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "[evals] --run-id requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local",
+    );
+  }
+  const { createClient } = await import("@supabase/supabase-js");
+  const supabase = createClient(url, key, { auth: { persistSession: false } });
+  const { data, error } = await supabase
+    .from("narrative_variants")
+    .select(
+      "rank, body, score, score_reasoning, predicted_sentiment, avg_position, mention_rate, evidence_refs, simulator_run_id",
+    )
+    .eq("simulator_run_id", run_id)
+    .order("rank", { ascending: true });
+
+  if (error) throw new Error(`[evals] Supabase error: ${error.message}`);
+  if (!data || data.length === 0) {
+    throw new Error(`[evals] no variants found for simulator_run_id=${run_id}`);
+  }
+
+  const variants: EvalVariant[] = data.map((row) => EvalVariantSchema.parse(row));
+  return {
+    fixture_id: `supabase:${run_id}`,
+    description: `Loaded ${variants.length} variants from Supabase for simulator_run_id=${run_id}`,
+    brand_name: "Attio",
+    variants,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown report builder
+// ---------------------------------------------------------------------------
+
+function flagEmoji(value: number, threshold: number, lowerIsBetter = true): string {
+  if (lowerIsBetter) {
+    if (value <= threshold) return "✅";
+    if (value <= threshold * 1.5) return "⚠️";
+    return "❌";
+  }
+  if (value >= threshold) return "✅";
+  if (value >= threshold * 0.66) return "⚠️";
+  return "❌";
+}
+
+function renderLayer1(report: DiversityReport): string {
+  const lines: string[] = [];
+  lines.push("## Layer 1 — Deterministic diversity\n");
+  lines.push(`- variant_count: ${report.variant_count}`);
+  lines.push(
+    `- opening_unique_ratio: ${report.opening_unique_ratio.toFixed(2)} ${flagEmoji(report.opening_unique_ratio, 1, false)} (1.0 = all openings unique)`,
+  );
+  lines.push(
+    `- trigram_jaccard_pairwise_avg: ${report.trigram_jaccard_pairwise_avg.toFixed(3)} ${flagEmoji(report.trigram_jaccard_pairwise_avg, 0.3)} (>0.30 = high overlap)`,
+  );
+  lines.push(
+    `- trigram_jaccard_max: ${report.trigram_jaccard_max.toFixed(3)} ${flagEmoji(report.trigram_jaccard_max, 0.4)}`,
+  );
+  lines.push(
+    `- structural_pattern_count: ${report.structural_pattern_count}/${report.variant_count} match \`but…At Attio\` template ${flagEmoji(report.structural_pattern_count, 1)}`,
+  );
+  lines.push(
+    `- length_cv: ${report.length_cv.toFixed(3)} ${flagEmoji(report.length_cv, 0.1, false)} (low CV = uniform length)`,
+  );
+  lines.push("");
+  lines.push("**Forbidden phrase hits:**");
+  if (report.forbidden_hits.every((h) => h.matches.length === 0)) {
+    lines.push("- ✅ none");
+  } else {
+    for (const h of report.forbidden_hits) {
+      if (h.matches.length === 0) continue;
+      lines.push(`- variant #${h.variant_idx}: ${h.matches.join(", ")} ❌`);
+    }
+  }
+  lines.push("");
+  lines.push("**AI-trope hits:**");
+  if (report.ai_trope_hits.every((h) => h.matches.length === 0)) {
+    lines.push("- ✅ none");
+  } else {
+    for (const h of report.ai_trope_hits) {
+      if (h.matches.length === 0) continue;
+      lines.push(`- variant #${h.variant_idx}: ${h.matches.join(", ")} ❌`);
+    }
+  }
+  lines.push("");
+  if (report.flags.length > 0) {
+    lines.push("**Flags:**");
+    for (const f of report.flags) lines.push(`- ${f}`);
+  } else {
+    lines.push("**Flags:** ✅ none");
+  }
+  return lines.join("\n");
+}
+
+function renderLayer2(report: JudgeReport | { skipped: string }): string {
+  const lines: string[] = ["", "## Layer 2 — LLM brand-voice judge (claude-sonnet-4-5)\n"];
+  if ("skipped" in report) {
+    lines.push(`_Skipped: ${report.skipped}_`);
+    return lines.join("\n");
+  }
+  lines.push(
+    `- diversity: **${report.diversity.score}/5** — ${report.diversity.reasoning}`,
+  );
+  lines.push("");
+  lines.push("**Brand voice fit per variant:**");
+  for (const v of report.brand_voice_fit) {
+    lines.push(
+      `- variant #${v.variant_idx}: **${v.score}/5** — ${v.violations.length === 0 ? "no violations" : v.violations.join("; ")}`,
+    );
+  }
+  lines.push("");
+  lines.push(`- worst_offender_idx: **${report.worst_offender_idx}**`);
+  lines.push(`- top_fix: ${report.top_fix}`);
+  return lines.join("\n");
+}
+
+function renderLayer3(report: SensitivityReport | { skipped: string }): string {
+  const lines: string[] = ["", "## Layer 3 — Scoring sensitivity probe\n"];
+  if ("skipped" in report) {
+    lines.push(`_Skipped: ${report.skipped}_`);
+    return lines.join("\n");
+  }
+  lines.push(`Total LLM calls: ${report.total_llm_calls}`);
+  lines.push("");
+  for (const c of report.cases) {
+    const emoji = c.flag === "pass" ? "✅" : c.flag === "warn" ? "⚠️" : "❌";
+    lines.push(`### Case: \`${c.case_id}\` ${emoji}`);
+    lines.push(`Expectation: ${c.expectation}`);
+    lines.push("");
+    lines.push(
+      `| label | mention_rate | avg_position | score |`,
+    );
+    lines.push(`|---|---|---|---|`);
+    lines.push(
+      `| ${c.a.label} | ${c.a.mention_rate.toFixed(2)} | ${c.a.avg_position?.toFixed(2) ?? "null"} | ${c.a.score.toFixed(3)} |`,
+    );
+    lines.push(
+      `| ${c.b.label} | ${c.b.mention_rate.toFixed(2)} | ${c.b.avg_position?.toFixed(2) ?? "null"} | ${c.b.score.toFixed(3)} |`,
+    );
+    lines.push("");
+    lines.push(
+      `Δscore = ${c.delta_score.toFixed(3)} · Δmention_rate = ${c.delta_mention_rate.toFixed(2)}`,
+    );
+    lines.push("");
+  }
+  lines.push(
+    report.hypothesis_confirmed
+      ? "**Hypothesis CONFIRMED:** at least one contrast pair shows insufficient Δscore — judges are not sufficiently sensitive to variant body. Scoring methodology needs redesign."
+      : "**Hypothesis REJECTED:** all contrast pairs show meaningful Δscore — judges respond to body content as intended.",
+  );
+  return lines.join("\n");
+}
+
+function recommendFixes(
+  layer1: DiversityReport,
+  layer2: JudgeReport | { skipped: string },
+  layer3: SensitivityReport | { skipped: string },
+): string[] {
+  const fixes: string[] = [];
+
+  if (
+    layer1.structural_pattern_count >= 2 ||
+    layer1.trigram_jaccard_pairwise_avg > 0.3 ||
+    layer1.opening_unique_ratio < 1
+  ) {
+    fixes.push(
+      "Rewrite simulator prompt to require ANGLE diversity (e.g. data model vs migration cost vs API ergonomics vs price), not just N variants. Forbid the 'competitor X, but At Attio…' template.",
+    );
+  }
+  const totalForbidden = layer1.forbidden_hits.reduce(
+    (a, h) => a + h.matches.length,
+    0,
+  );
+  const totalTropes = layer1.ai_trope_hits.reduce(
+    (a, h) => a + h.matches.length,
+    0,
+  );
+  if (totalForbidden + totalTropes > 0) {
+    fixes.push(
+      `Add a forbidden-phrase post-filter before persist (or inject the list into the simulator prompt as 'NEVER use'). ${totalForbidden} forbidden + ${totalTropes} trope hits this run.`,
+    );
+  }
+
+  if (!("skipped" in layer3) && layer3.hypothesis_confirmed) {
+    fixes.push(
+      "Replace the global ranking-prompt scoring with a body-relative metric (e.g. per-variant embedding similarity to brand voice corpus, or ask the judge to RATE the variant directly instead of re-ranking the brand list).",
+    );
+  }
+
+  if (!("skipped" in layer2) && layer2.top_fix) {
+    fixes.push(`Judge-recommended top fix: ${layer2.top_fix}`);
+  }
+
+  return fixes;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  loadEnvLocal();
+  const args = parseArgs(process.argv.slice(2));
+  const startedAt = new Date();
+
+  console.error(`[evals] starting at ${startedAt.toISOString()}`);
+  console.error(`[evals] config:`, args);
+
+  // 1. Load fixture (file or Supabase)
+  const fixture: FixtureFile = args.runId
+    ? await loadFromSupabase(args.runId)
+    : loadFixtureFile(args.fixture);
+  console.error(
+    `[evals] loaded ${fixture.variants.length} variant(s) from "${fixture.fixture_id}"`,
+  );
+
+  // 2. Layer 1 — diversity (always runs, deterministic)
+  console.error("[evals] Layer 1: computing diversity metrics…");
+  const layer1 = computeDiversity(fixture.variants);
+
+  // 3. Layer 2 — judge (skippable)
+  let layer2: JudgeReport | { skipped: string };
+  if (args.skipJudge) {
+    layer2 = { skipped: "--no-judge flag" };
+  } else if (!process.env.ANTHROPIC_API_KEY) {
+    layer2 = { skipped: "ANTHROPIC_API_KEY not set" };
+    console.warn("[evals] Layer 2 skipped: missing ANTHROPIC_API_KEY");
+  } else {
+    console.error("[evals] Layer 2: running brand-voice judge (claude-sonnet-4-5)…");
+    try {
+      layer2 = await runBrandVoiceJudge({
+        brand_name: fixture.brand_name,
+        variants: fixture.variants,
+      });
+    } catch (err) {
+      const msg = (err as Error).message;
+      console.warn(`[evals] Layer 2 errored: ${msg}`);
+      layer2 = { skipped: `runtime error: ${msg}` };
+    }
+  }
+
+  // 4. Layer 3 — scoring sensitivity probe (skippable)
+  let layer3: SensitivityReport | { skipped: string };
+  if (args.skipSensitivity) {
+    layer3 = { skipped: "--no-sensitivity flag" };
+  } else if (!process.env.OPENAI_API_KEY || !process.env.ANTHROPIC_API_KEY) {
+    layer3 = {
+      skipped: "OPENAI_API_KEY and/or ANTHROPIC_API_KEY not set",
+    };
+    console.warn(
+      "[evals] Layer 3 skipped: missing OPENAI_API_KEY and/or ANTHROPIC_API_KEY",
+    );
+  } else {
+    console.error("[evals] Layer 3: running scoring sensitivity probe (~60 LLM calls)…");
+    try {
+      const contrast = loadContrastFixtureFile(args.contrastFixture);
+      layer3 = await runScoringSensitivity(contrast);
+    } catch (err) {
+      const msg = (err as Error).message;
+      console.warn(`[evals] Layer 3 errored: ${msg}`);
+      layer3 = { skipped: `runtime error: ${msg}` };
+    }
+  }
+
+  // 5. Build full report
+  const top_fixes = recommendFixes(layer1, layer2, layer3);
+  const full: FullEvalReport = {
+    generated_at: startedAt.toISOString(),
+    fixture_id: fixture.fixture_id,
+    brand_name: fixture.brand_name,
+    layer_1: layer1,
+    layer_2: layer2,
+    layer_3: layer3,
+    top_fixes,
+  };
+
+  // 6. Render markdown
+  const md = [
+    `# BBH W5 evals report — ${startedAt.toISOString()}`,
+    "",
+    `Fixture: \`${fixture.fixture_id}\` (${fixture.description})`,
+    `Brand: **${fixture.brand_name}**`,
+    `Variants evaluated: ${fixture.variants.length}`,
+    "",
+    "---",
+    "",
+    renderLayer1(layer1),
+    renderLayer2(layer2),
+    renderLayer3(layer3),
+    "",
+    "---",
+    "",
+    "## Recommended next-plan fixes",
+    "",
+    top_fixes.length === 0
+      ? "_No fixes needed — variants pass all checks._"
+      : top_fixes.map((f, i) => `${i + 1}. ${f}`).join("\n"),
+    "",
+    "---",
+    "",
+    "<details><summary>Raw report JSON</summary>",
+    "",
+    "```json",
+    JSON.stringify(full, null, 2),
+    "```",
+    "",
+    "</details>",
+    "",
+  ].join("\n");
+
+  // 7. Write report file
+  mkdirSync(REPORTS_DIR, { recursive: true });
+  const safeStamp = startedAt.toISOString().replace(/[:.]/g, "-");
+  const reportPath = resolve(
+    REPORTS_DIR,
+    `${safeStamp}__${fixture.fixture_id.replace(/[^a-z0-9-]/gi, "-")}.md`,
+  );
+  writeFileSync(reportPath, md, "utf8");
+  console.error(`[evals] wrote report → ${reportPath}`);
+
+  // 8. Print to stdout
+  process.stdout.write(md);
+}
+
+main().catch((err) => {
+  console.error("[evals] fatal:", err);
+  process.exit(1);
+});

--- a/evals/scoring-sensitivity.ts
+++ b/evals/scoring-sensitivity.ts
@@ -1,0 +1,211 @@
+// Layer 3 — scoring sensitivity probe.
+//
+// Replicates the production scoring step from inngest/functions/narrative-simulator.ts
+// (gather-context → score-variants) on three contrast pairs. If the pairs that
+// SHOULD differ in score (attio_vs_competitor, real_vs_gibberish) come out
+// near-identical, that confirms the user's hypothesis that the ranking-prompt
+// judges return the same Attio ranking from baseline brand knowledge,
+// regardless of the variant body.
+
+import { z } from "zod";
+
+import {
+  evalGenerateObjectAnthropic,
+  evalGenerateObjectOpenAI,
+} from "./lib/llm";
+import {
+  aggregateScores,
+  computeScore,
+  FALLBACK_SCORING_PROMPTS,
+  findBrandPosition,
+} from "./lib/scoring";
+import type {
+  ContrastFixture,
+  ScoredVariant,
+  SensitivityCase,
+  SensitivityReport,
+} from "./lib/types";
+
+// Same shape the production simulator uses for the per-prompt ranking call.
+const BrandRankingSchema = z.object({
+  brand_ranking: z.array(z.string()).max(15),
+  reasoning: z.string().min(1),
+});
+type BrandRanking = z.infer<typeof BrandRankingSchema>;
+
+function buildRankingPrompt(
+  brand_name: string,
+  variant_body: string,
+  panel_prompt: string,
+): string {
+  return [
+    `Brand-positioning context (a candidate counter-narrative for ${brand_name}):`,
+    `"""`,
+    variant_body,
+    `"""`,
+    ``,
+    `Question: ${panel_prompt}`,
+    ``,
+    `List up to 10 brand names ordered by how strongly you would recommend them, most-recommended first. Provide a one-sentence reasoning.`,
+  ].join("\n");
+}
+
+interface ScoreOnceArgs {
+  label: string;
+  body: string;
+  brand_name: string;
+  panel_prompts: readonly string[];
+}
+
+// Cache by body hash (string identity) so the identical pair only burns one
+// real LLM call per (prompt × model) combination instead of two.
+const scoreCache = new Map<string, ScoredVariant>();
+
+function cacheKey(body: string, brand_name: string): string {
+  return `${brand_name}::${body}`;
+}
+
+async function scoreVariantOnce(args: ScoreOnceArgs): Promise<{
+  scored: ScoredVariant;
+  llm_calls: number;
+}> {
+  const key = cacheKey(args.body, args.brand_name);
+  const cached = scoreCache.get(key);
+  if (cached) {
+    return { scored: { ...cached, label: args.label }, llm_calls: 0 };
+  }
+
+  const positions: Array<number | null> = [];
+  let calls = 0;
+
+  for (const panel_prompt of args.panel_prompts) {
+    const ranking_prompt = buildRankingPrompt(
+      args.brand_name,
+      args.body,
+      panel_prompt,
+    );
+    const [openaiRes, anthropicRes] = await Promise.all([
+      evalGenerateObjectOpenAI<BrandRanking>({
+        schema: BrandRankingSchema,
+        prompt: ranking_prompt,
+        model: "gpt-4o-mini",
+        schemaName: "BrandRanking",
+        temperature: 0,
+      }),
+      evalGenerateObjectAnthropic<BrandRanking>({
+        schema: BrandRankingSchema,
+        prompt: ranking_prompt,
+        model: "claude-haiku-4-5-20251001",
+        schemaName: "BrandRanking",
+        temperature: 0,
+      }),
+    ]);
+    calls += 2;
+    positions.push(
+      findBrandPosition(openaiRes.object.brand_ranking, args.brand_name),
+      findBrandPosition(anthropicRes.object.brand_ranking, args.brand_name),
+    );
+  }
+
+  const { mention_rate, avg_position } = aggregateScores(positions);
+  const score = computeScore(mention_rate, avg_position);
+
+  const scored: ScoredVariant = {
+    label: args.label,
+    body_preview: args.body.slice(0, 120),
+    positions,
+    mention_rate,
+    avg_position,
+    score,
+  };
+  scoreCache.set(key, scored);
+  return { scored, llm_calls: calls };
+}
+
+const CASE_EXPECTATIONS: Record<
+  SensitivityCase["case_id"],
+  { expectation: string; significant_delta: number }
+> = {
+  identical: {
+    expectation: "Δscore == 0 (deterministic with temp=0)",
+    significant_delta: 0.001,
+  },
+  attio_vs_competitor: {
+    expectation: "Δscore >> 0; Attio variant scores higher than competitor variant",
+    significant_delta: 0.1,
+  },
+  real_vs_gibberish: {
+    expectation: "Δscore >> 0; real Attio variant scores higher than lorem ipsum",
+    significant_delta: 0.1,
+  },
+};
+
+export async function runScoringSensitivity(
+  fixture: ContrastFixture,
+): Promise<SensitivityReport> {
+  scoreCache.clear();
+  const { brand_name } = fixture;
+  const panel_prompts = FALLBACK_SCORING_PROMPTS;
+
+  const cases: SensitivityCase[] = [];
+  let total_llm_calls = 0;
+
+  for (const case_id of [
+    "identical",
+    "attio_vs_competitor",
+    "real_vs_gibberish",
+  ] as const) {
+    const pair = fixture.pairs[case_id];
+    const exp = CASE_EXPECTATIONS[case_id];
+
+    const aRes = await scoreVariantOnce({
+      label: `${case_id}.a`,
+      body: pair.a,
+      brand_name,
+      panel_prompts,
+    });
+    const bRes = await scoreVariantOnce({
+      label: `${case_id}.b`,
+      body: pair.b,
+      brand_name,
+      panel_prompts,
+    });
+    total_llm_calls += aRes.llm_calls + bRes.llm_calls;
+
+    const delta_score = Math.abs(aRes.scored.score - bRes.scored.score);
+    const delta_mention_rate = Math.abs(
+      aRes.scored.mention_rate - bRes.scored.mention_rate,
+    );
+
+    let flag: SensitivityCase["flag"];
+    if (case_id === "identical") {
+      flag = delta_score <= exp.significant_delta ? "pass" : "fail";
+    } else {
+      // For contrast pairs we want a LARGE delta. Small delta → judges ignore body.
+      if (delta_score >= exp.significant_delta) flag = "pass";
+      else if (delta_score >= exp.significant_delta / 2) flag = "warn";
+      else flag = "fail";
+    }
+
+    cases.push({
+      case_id,
+      expectation: exp.expectation,
+      a: aRes.scored,
+      b: bRes.scored,
+      delta_score,
+      delta_mention_rate,
+      flag,
+    });
+  }
+
+  const failingContrast = cases
+    .filter((c) => c.case_id !== "identical")
+    .filter((c) => c.flag !== "pass");
+  const hypothesis_confirmed = failingContrast.length > 0;
+
+  return {
+    cases,
+    hypothesis_confirmed,
+    total_llm_calls,
+  };
+}

--- a/inngest/functions/competitor-radar.ts
+++ b/inngest/functions/competitor-radar.ts
@@ -256,6 +256,92 @@ export const competitorRadar = inngest.createFunction(
       return out;
     })) as SignalCandidate[];
 
+    // 3a. Peec per-prompt signals -------------------------------------------
+    //    For each Peec prompt × competitor — обчислити mention_rate з
+    //    snapshot.chats з matching prompt_id. Якщо competitor згаданий хоча б
+    //    у одному chat — emit signal. Severity proportional to mention_rate
+    //    (high when competitor dominates query, indicating Attio's own gap).
+    //    Source URL deeplinks до Peec project prompt page для evidence.
+    //    Розширюється autoматично коли peec-snapshot.json content updated
+    //    (more prompts → more signals, без code change).
+    const peecPromptCandidates = (await step.run("peec-per-prompt-signals", async () => {
+      const out: SignalCandidate[] = [];
+      const allChats = snapshot.chats ?? [];
+      const allPrompts = snapshot.prompts ?? [];
+      // Pre-build prompt → chats lookup для O(1) per prompt.
+      const chatsByPromptId = new Map<string, typeof allChats>();
+      for (const chat of allChats) {
+        const arr = chatsByPromptId.get(chat.prompt_id) ?? [];
+        arr.push(chat);
+        chatsByPromptId.set(chat.prompt_id, arr);
+      }
+
+      for (const prompt of allPrompts) {
+        const chatsForPrompt = chatsByPromptId.get(prompt.id) ?? [];
+        if (chatsForPrompt.length === 0) continue;
+        const totalChats = chatsForPrompt.length;
+
+        for (const comp of competitors) {
+          const peecBrand = snapshot.brands.find(
+            (b) => b.name.toLowerCase() === comp.display_name.toLowerCase(),
+          );
+          if (!peecBrand) continue;
+          const brandNameLower = comp.display_name.toLowerCase();
+
+          // Match by brand name OR brand id у brands_mentioned (snapshot uses
+          // mixed identifiers depending on Peec MCP version).
+          const mentionedChats = chatsForPrompt.filter((c) =>
+            c.brands_mentioned.some(
+              (b) =>
+                b.toLowerCase() === brandNameLower ||
+                b === peecBrand.id,
+            ),
+          );
+          if (mentionedChats.length === 0) continue;
+
+          const mentionRate = mentionedChats.length / totalChats;
+          // Severity by competitor dominance — high mention_rate = competitor
+          // owns the query → high signal (Attio's gap is large).
+          // Thresholds tuned conservatively (0.7 high) щоб обмежити auto-draft
+          // fan-out у W9 high-severity loop (counter-draft generation cost).
+          const severity: "low" | "med" | "high" =
+            mentionRate >= 0.7 ? "high" : mentionRate >= 0.4 ? "med" : "low";
+
+          const sourceUrl = `https://app.peec.ai/projects/${snapshot.project_id}/prompts/${prompt.id}`;
+          const promptText = prompt.text.length > 100
+            ? `${prompt.text.slice(0, 97)}...`
+            : prompt.text;
+
+          out.push({
+            source_type: "peec_delta",
+            source_url: sourceUrl,
+            severity,
+            sentiment: "neutral", // mention rate саме по собі не carry sentiment
+            summary: `${comp.display_name} mentioned у ${(mentionRate * 100).toFixed(0)}% of "${promptText}" chats (${mentionedChats.length}/${totalChats}).`,
+            reasoning: `Peec prompt-level signal: competitor ${comp.display_name} appears у ${mentionedChats.length} of ${totalChats} LLM responses до prompt "${promptText}". High mention_rate означає competitor owns this query category.`,
+            evidence_refs: [sourceUrl],
+            competitor_id: comp.id,
+            position: null,
+            peec_meta: {
+              captured_at: snapshot.captured_at,
+              project_id: snapshot.project_id,
+              brand_id: peecBrand.id,
+            },
+          });
+        }
+      }
+      return out;
+    })) as SignalCandidate[];
+
+    // Combined pool — both delta/baseline (step 3) і per-prompt (step 3a) signals
+    // flow through same dedup/persist downstream. Source type залишається
+    // "peec_delta" тому UI tag'ить як 📊 Peec. Build new array замість мутації
+    // step.run result (Inngest replay-safe pattern).
+    const allPeecCandidates: SignalCandidate[] = [
+      ...peecCandidates,
+      ...peecPromptCandidates,
+    ];
+
     // 4. Tavily supplement (3 parallel queries: news + x + linkedin) ----------
     //    Per (competitor, term) we fan out to 3 channels — news index (last 2d),
     //    Twitter/X domain restrict, LinkedIn domain restrict. Each result is
@@ -414,7 +500,7 @@ export const competitorRadar = inngest.createFunction(
         }
       }
 
-      const dedupedPeec = peecCandidates.filter(
+      const dedupedPeec = allPeecCandidates.filter(
         (p) => !existingPeecKeys.has(`${p.source_url}|${p.summary}`),
       );
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
     "tailwindcss-animate": "^1.0.7",
+    "tsx": "^4.21.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,10 +83,13 @@ importers:
         version: 8.5.10
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.19(yaml@2.8.3)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(yaml@2.8.3))
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -221,9 +224,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -233,9 +248,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -245,9 +272,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -257,9 +296,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -269,9 +320,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -281,9 +344,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -293,9 +368,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -305,9 +392,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -317,11 +416,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -329,9 +452,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -341,15 +482,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1919,6 +2078,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3229,6 +3393,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3580,70 +3749,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -5502,6 +5749,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6458,12 +6734,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.10
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.10
+      tsx: 4.21.0
       yaml: 2.8.3
 
   postcss-nested@6.2.0(postcss@8.5.10):
@@ -6912,11 +7189,11 @@ snapshots:
 
   tailwind-merge@2.6.1: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(yaml@2.8.3)):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      tailwindcss: 3.4.19(yaml@2.8.3)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
 
-  tailwindcss@3.4.19(yaml@2.8.3):
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -6935,7 +7212,7 @@ snapshots:
       postcss: 8.5.10
       postcss-import: 15.1.0(postcss@8.5.10)
       postcss-js: 4.1.0(postcss@8.5.10)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -6997,6 +7274,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
Розширює W9 generating Peec signals per (prompt × competitor) pair замість тільки per brand baseline. Few Peec badges у dashboard → багато (auto-scales з content peec-snapshot.json).

## Changes
- New step `peec-per-prompt-signals` після `peec-delta-detect`
- Iterates `snapshot.prompts × competitors`, counts mention rate з chats з matching prompt_id
- Severity thresholds conservative (0.7 high / 0.4 med) щоб не спамити counter-drafts
- Source URL deeplinks до Peec project prompt page для evidence
- Replay-safe: `allPeecCandidates = [...delta, ...per-prompt]` без мутації step result

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 66/66
- [x] `pnpm build` success
- [x] code-reviewer agent pass (all 4 gates)
- [ ] Browser smoke after deploy: тригерну W9 → expect ~10-25 Peec badges (vs previous 2)
- [ ] Refresh peec-snapshot.json до 50 prompts через MCP → auto-scales до ~50-100 signals

## Risk
CRITICAL zone (`inngest/functions/competitor-radar.ts`) — code-reviewer agent pass + 4-gate verification. No schema/event/migration changes. Rollback: `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)